### PR TITLE
Creadas las ValidationRule del objeto Sprint__c.

### DIFF
--- a/force-app/main/default/objects/Sprint__c/validationRules/CheckEndDate.validationRule-meta.xml
+++ b/force-app/main/default/objects/Sprint__c/validationRules/CheckEndDate.validationRule-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+	<active>true</active>
+	<description>Valida que la fecha de fin de tarea sea mayor que la de inicio</description>
+	<errorConditionFormula>EndDate__c &lt;  StartDate__c</errorConditionFormula>
+	<errorDisplayField>EndDate__c</errorDisplayField>
+	<errorMessage>End Date must be higher than Start Date</errorMessage>
+	<fullName>CheckEndDate</fullName>
+</ValidationRule>

--- a/force-app/main/default/objects/Sprint__c/validationRules/CheckEndDateProJet.validationRule-meta.xml
+++ b/force-app/main/default/objects/Sprint__c/validationRules/CheckEndDateProJet.validationRule-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+	<active>true</active>
+	<description>Valida que la fecha de fin de la tarea no sea mayor que la fecha de fin de proyecto.</description>
+	<errorConditionFormula>EndDate__c &gt;  Project__r.EndDate__c</errorConditionFormula>
+	<errorDisplayField>EndDate__c</errorDisplayField>
+	<errorMessage>End Date can&apos;t be higher than Project End Date</errorMessage>
+	<fullName>CheckEndDateProJet</fullName>
+</ValidationRule>

--- a/force-app/main/default/objects/Sprint__c/validationRules/RequiredComment.validationRule-meta.xml
+++ b/force-app/main/default/objects/Sprint__c/validationRules/RequiredComment.validationRule-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+	<active>true</active>
+	<description>Valida que el campo Comment__c este relleno.</description>
+	<errorConditionFormula>Comment__c == null</errorConditionFormula>
+	<errorDisplayField>Comment__c</errorDisplayField>
+	<errorMessage>Sprint Comment Required. Please add a commentbefore save</errorMessage>
+	<fullName>RequiredComment</fullName>
+</ValidationRule>

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
 	<types>
-		<members>Issue__c.CheckParentIssue</members>
+		<members>Sprint__c.CheckEndDate</members>
+		<members>Sprint__c.CheckEndDateProJet</members>
+		<members>Sprint__c.RequiredComment</members>
 		<name>ValidationRule</name>
 	</types>
 	<version>54.0</version>


### PR DESCRIPTION
Hace obligatorio el campo comment__c, valida que la fecha de fin de la tarea no sea menor que la de inicio de tarea ni mayor que la de fin de proyecto