### PR TITLE
Creada la clave única para el objeto ProjectCollaborator__c

### DIFF
--- a/force-app/main/default/classes/ProjectCollaboratorTriggerHandler.cls
+++ b/force-app/main/default/classes/ProjectCollaboratorTriggerHandler.cls
@@ -19,9 +19,7 @@ public without sharing class ProjectCollaboratorTriggerHandler extends TriggerHa
     public override void beforeUpdate(SObject newRecord, SObject oldRecord){
         acn__ProjectCollaborator__c newProjectCollaborator = (acn__ProjectCollaborator__c) newRecord;
         acn__ProjectCollaborator__c oldProjectCollaborator = (acn__ProjectCollaborator__c) oldRecord;
-        if (newProjectCollaborator.acn__Project__c != oldProjectCollaborator.acn__Project__c || newProjectCollaborator.acn__Contact__c != oldProjectCollaborator.acn__Contact__c){
-            ProjectCollaboratorTriggerHelper.setUniqueKey(newProjectCollaborator);
-        }
+        ProjectCollaboratorTriggerHelper.setUniqueKey(newProjectCollaborator);
     }
 
 }

--- a/force-app/main/default/classes/ProjectCollaboratorTriggerHandler.cls
+++ b/force-app/main/default/classes/ProjectCollaboratorTriggerHandler.cls
@@ -1,0 +1,27 @@
+public without sharing class ProjectCollaboratorTriggerHandler extends TriggerHandler{
+    private static ProjectCollaboratorTriggerHandler singleton;
+
+    private ProjectCollaboratorTriggerHandler(){
+    }
+
+    public static ProjectCollaboratorTriggerHandler getInstance(){
+        if (singleton == null){
+            singleton = new ProjectCollaboratorTriggerHandler();
+        }
+        return singleton;
+    }
+
+    public override void beforeInsert(SObject newRecord){
+        acn__ProjectCollaborator__c newProjectCollaborator = (acn__ProjectCollaborator__c) newRecord;
+        ProjectCollaboratorTriggerHelper.setUniqueKey(newProjectCollaborator);
+    }
+
+    public override void beforeUpdate(SObject newRecord, SObject oldRecord){
+        acn__ProjectCollaborator__c newProjectCollaborator = (acn__ProjectCollaborator__c) newRecord;
+        acn__ProjectCollaborator__c oldProjectCollaborator = (acn__ProjectCollaborator__c) oldRecord;
+        if (newProjectCollaborator.acn__Project__c != oldProjectCollaborator.acn__Project__c || newProjectCollaborator.acn__Contact__c != oldProjectCollaborator.acn__Contact__c){
+            ProjectCollaboratorTriggerHelper.setUniqueKey(newProjectCollaborator);
+        }
+    }
+
+}

--- a/force-app/main/default/classes/ProjectCollaboratorTriggerHandler.cls-meta.xml
+++ b/force-app/main/default/classes/ProjectCollaboratorTriggerHandler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ProjectCollaboratorTriggerHelper.cls
+++ b/force-app/main/default/classes/ProjectCollaboratorTriggerHelper.cls
@@ -1,0 +1,6 @@
+public with sharing class ProjectCollaboratorTriggerHelper {
+    
+    public static void setUniqueKey (acn__ProjectCollaborator__c newProjectCollaborator){
+        newProjectCollaborator.acn__Unique_Key__c = acn__ProjectCollaborator__c.acn__Project__c + '-' + acn__ProjectCollaborator__c.acn__Contact__c;
+    }
+}

--- a/force-app/main/default/classes/ProjectCollaboratorTriggerHelper.cls
+++ b/force-app/main/default/classes/ProjectCollaboratorTriggerHelper.cls
@@ -1,6 +1,6 @@
 public with sharing class ProjectCollaboratorTriggerHelper {
     
     public static void setUniqueKey (acn__ProjectCollaborator__c newProjectCollaborator){
-        newProjectCollaborator.acn__Unique_Key__c = acn__ProjectCollaborator__c.acn__Project__c + '-' + acn__ProjectCollaborator__c.acn__Contact__c;
+        newProjectCollaborator.acn__Unique_Key__c = newProjectCollaborator.acn__Project__c + '-' + newProjectCollaborator.acn__Contact__c;
     }
 }

--- a/force-app/main/default/classes/ProjectCollaboratorTriggerHelper.cls-meta.xml
+++ b/force-app/main/default/classes/ProjectCollaboratorTriggerHelper.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ProjectCollaboratorTriggerTest.cls
+++ b/force-app/main/default/classes/ProjectCollaboratorTriggerTest.cls
@@ -1,0 +1,73 @@
+@isTest
+public with sharing class ProjectCollaboratorTriggerTest {
+
+    private static Contact contact {
+        get{
+            if (contact == null){
+                contact = [Select Id from Contact where LastName = 'Test Contact'];
+            }
+            return contact;
+        }
+        set;
+    }
+    private static acn__Project__c project {
+        get {
+            if (project == null){
+                project = [Select Id from acn__Project__c where name = 'Test Project'];
+            }
+            return project;
+        }
+        set;
+    }
+
+    @TestSetup
+    public static void testSetUp(){
+
+        Account account = TestDataFactory.createAccount('Test Account');
+        insert account;
+        contact = TestDataFactory.createContact('Test Contact', account.Id, userInfo.getUserId());
+        insert contact;
+        project = TestDataFactory.createProject('Test Project', 'ABC', contact.Id);
+        insert project;
+
+    }
+
+    @isTest
+    public static void testInsertProjectCollaborator(){
+
+        acn__ProjectCollaborator__c newProjectCollaborator = new acn__ProjectCollaborator__c();
+        newProjectCollaborator.acn__Contact__c = contact.Id;
+        newProjectCollaborator.acn__Project__c = project.Id;
+        newProjectCollaborator.acn__Role__c = 'Desarrollador';
+
+        Test.startTest();
+        insert newProjectCollaborator;
+        Test.stopTest();
+
+        acn__ProjectCollaborator__c projectResult = [Select Id, acn__Unique_Key__c from acn__ProjectCollaborator__c where Id = :newProjectCollaborator.Id];
+
+        System.assertEquals(project.Id + '-' + contact.Id, projectResult.acn__Unique_Key__c);
+    }
+
+    @isTest
+    public static void testUpdateProjectCollaborator(){
+        acn__ProjectCollaborator__c newProjectCollaborator = new acn__ProjectCollaborator__c();
+        newProjectCollaborator.acn__Contact__c = contact.Id;
+        newProjectCollaborator.acn__Project__c = project.Id;
+        newProjectCollaborator.acn__Role__c = 'Desarrollador';
+
+        acn__Project__c  project2 = TestDataFactory.createProject('Test Project2', 'ABCD', contact.Id);
+        insert project2;
+
+        Test.startTest();
+        insert newProjectCollaborator;
+        newProjectCollaborator.acn__Project__c = project2.Id;
+        update newProjectCollaborator;
+        Test.stopTest();
+
+        acn__ProjectCollaborator__c projectResult = [Select Id, acn__Unique_Key__c from acn__ProjectCollaborator__c where Id = :newProjectCollaborator.Id];
+
+        System.assertEquals(project2.Id + '-' + contact.Id , projectResult.acn__Unique_Key__c);
+    }
+   
+}

--- a/force-app/main/default/classes/ProjectCollaboratorTriggerTest.cls-meta.xml
+++ b/force-app/main/default/classes/ProjectCollaboratorTriggerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/ProjectTriggerTest.cls
+++ b/force-app/main/default/classes/ProjectTriggerTest.cls
@@ -18,7 +18,7 @@ public with sharing class ProjectTriggerTest{
 
         Account account = TestDataFactory.createAccount('Test Account');
         insert account;
-        Contact contact = TestDataFactory.createContact('Test Contact', account.Id, userInfo.getUserId());
+        contact = TestDataFactory.createContact('Test Contact', account.Id, userInfo.getUserId());
         insert contact;
     }
 

--- a/force-app/main/default/objects/ProjectCollaborator__c/fields/Unique_Key__c.field-meta.xml
+++ b/force-app/main/default/objects/ProjectCollaborator__c/fields/Unique_Key__c.field-meta.xml
@@ -6,7 +6,7 @@
 	<fullName>Unique_Key__c</fullName>
 	<label>Unique Key</label>
 	<length>255</length>
-	<required>true</required>
+	<required>false</required>
 	<trackTrending>false</trackTrending>
 	<type>Text</type>
 	<unique>true</unique>

--- a/force-app/main/default/triggers/ProjectCollaboratorTrigger.trigger
+++ b/force-app/main/default/triggers/ProjectCollaboratorTrigger.trigger
@@ -1,0 +1,4 @@
+trigger ProjectCollaboratorTrigger on acn__ProjectCollaborator__c (before insert, before update) {
+
+    ProjectTriggerHandler.getInstance().run(acn__ProjectCollaborator__c.SObjectType);
+}

--- a/force-app/main/default/triggers/ProjectCollaboratorTrigger.trigger
+++ b/force-app/main/default/triggers/ProjectCollaboratorTrigger.trigger
@@ -1,4 +1,4 @@
 trigger ProjectCollaboratorTrigger on acn__ProjectCollaborator__c (before insert, before update) {
 
-    ProjectTriggerHandler.getInstance().run(acn__ProjectCollaborator__c.SObjectType);
+    ProjectCollaboratorTriggerHandler.getInstance().run(acn__ProjectCollaborator__c.SObjectType);
 }

--- a/force-app/main/default/triggers/ProjectCollaboratorTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/ProjectCollaboratorTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>54.0</apiVersion>
+  <status>Active</status>
+</ApexTrigger>


### PR DESCRIPTION
La clave única está formada por la concatenación del Id del proyecto y el Id del contacto con un con un guión bajo. (idProject + "_" + IdContact).  