### PR TITLE
Creada clave única para el objeto IssueWatcher__c

### DIFF
--- a/force-app/main/default/classes/IssueWatcherTriggerHandler.cls
+++ b/force-app/main/default/classes/IssueWatcherTriggerHandler.cls
@@ -1,0 +1,25 @@
+public without sharing class IssueWatcherTriggerHandler extends TriggerHandler{
+    private static IssueWatcherTriggerHandler singleton;
+
+    public IssueWatcherTriggerHandler() {
+
+    }
+
+    public static IssueWatcherTriggerHandler getInstance (){
+        if(singleton == null){
+            singleton = new IssueWatcherTriggerHandler();           
+        }
+        return singleton; 
+    }
+
+    public override void beforeInsert(SObject newRecord){
+        acn__IssueWatcher__c newIssueWatcher = (acn__IssueWatcher__c) newRecord;
+        IssueWatcherTriggerHelper.setUniqueKey(newIssueWatcher);
+    }
+
+    public override void beforeUpdate(SObject newRecord, SObject oldRecord){
+        acn__IssueWatcher__c newIssueWatcher = (acn__IssueWatcher__c) newRecord;
+        acn__IssueWatcher__c oldIssueWatcher = (acn__IssueWatcher__c) oldRecord;
+        IssueWatcherTriggerHelper.setUniqueKey(newIssueWatcher);
+    }
+}

--- a/force-app/main/default/classes/IssueWatcherTriggerHandler.cls-meta.xml
+++ b/force-app/main/default/classes/IssueWatcherTriggerHandler.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IssueWatcherTriggerHelper.cls
+++ b/force-app/main/default/classes/IssueWatcherTriggerHelper.cls
@@ -1,0 +1,6 @@
+public with sharing class IssueWatcherTriggerHelper {
+    
+    public static void setUniqueKey (acn__IssueWatcher__c newIssueWatcher){
+        newIssueWatcher.acn__UniqueKey__c = newIssueWatcher.acn__Issue__c + '_' + newIssueWatcher.acn__Contact__c;
+    }
+}

--- a/force-app/main/default/classes/IssueWatcherTriggerHelper.cls-meta.xml
+++ b/force-app/main/default/classes/IssueWatcherTriggerHelper.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IssueWatcherTriggerTest.cls
+++ b/force-app/main/default/classes/IssueWatcherTriggerTest.cls
@@ -1,0 +1,85 @@
+@istest
+public with sharing class IssueWatcherTriggerTest{
+    public static Contact Contact{ 
+        get {
+            if (contact == null){
+                contact = [Select Id from Contact where LastName = 'Test Contact'];
+            }
+            return contact;
+        }
+        set; 
+    }
+
+    public static acn__Project__c project{ 
+        get  {
+            if (project == null){
+                project = [Select Id from acn__Project__c where name = 'Test Project'];
+            }
+            return project;
+        } 
+        set; 
+    }
+
+    public static acn__Issue__c issue{
+         get {
+            if (issue == null){
+                issue = [Select Id from acn__Issue__c where acn__Headline__c = 'Test Issue'];
+            }
+            return issue;
+        }  
+         set; 
+    }
+
+    
+    @TestSetup
+    public static void testSetup(){
+        Account account = TestDataFactory.createAccount('Test Account');
+        insert account;
+        contact = TestDataFactory.createContact('Test Contact', account.Id, UserInfo.getUserId());
+        insert contact;
+        project = TestDataFactory.createProject('Test Project', 'ABC', contact.Id);
+        insert project;
+        issue = TestDataFactory.createIssue('Test Issue', contact.Id, project.Id);
+        insert issue;
+    }
+
+    @isTest
+    public static void testInsertIssueWatcher(){
+        acn__IssueWatcher__c newIssueWatcher = new acn__IssueWatcher__c();
+        newIssueWatcher.acn__Contact__c = contact.Id;
+        newIssueWatcher.acn__Issue__c = issue.Id;
+
+        Test.startTest();
+        insert newIssueWatcher;
+        Test.stopTest();
+
+        acn__IssueWatcher__c issueResult = [Select id, acn__UniqueKey__c from acn__IssueWatcher__c where Id = :newIssueWatcher.Id];
+
+        System.assertEquals(issue.Id + '_' + contact.Id , issueResult.acn__UniqueKey__c);
+    }
+
+    @isTest
+    public static void testUpdateIssueWatcher(){
+        acn__IssueWatcher__c newIssueWatcher = new acn__IssueWatcher__c();
+        newIssueWatcher.acn__Contact__c = contact.Id;
+        newIssueWatcher.acn__Issue__c = issue.Id;
+
+        //Contact contact2 = TestDataFactory.createContact('Test Contact2', account.Id, UserInfo.getUserId());
+        //insert contact2;
+        acn__Issue__c issue2 = TestDataFactory.createIssue('Test Issue2', contact.Id, project.Id);
+        insert issue2;
+
+        Test.startTest();
+        insert newIssueWatcher;
+        //newIssueWatcher.acn__Contact__c = contact2.Id;
+        newIssueWatcher.acn__Issue__c = issue2.Id;
+        update newIssueWatcher;
+        Test.stopTest();
+
+        acn__IssueWatcher__c issueResult = [Select id, acn__UniqueKey__c from acn__IssueWatcher__c where Id = :newIssueWatcher.Id];
+
+        System.assertEquals(issue2.Id + '_' + contact.Id , issueResult.acn__UniqueKey__c);
+    }
+
+
+}

--- a/force-app/main/default/classes/IssueWatcherTriggerTest.cls-meta.xml
+++ b/force-app/main/default/classes/IssueWatcherTriggerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>54.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/objects/IssueWatcher__c/fields/Unique_Key__c.field-meta.xml
+++ b/force-app/main/default/objects/IssueWatcher__c/fields/Unique_Key__c.field-meta.xml
@@ -6,7 +6,7 @@
 	<fullName>Unique_Key__c</fullName>
 	<label>Unique Key</label>
 	<length>255</length>
-	<required>true</required>
+	<required>false</required>
 	<trackTrending>false</trackTrending>
 	<type>Text</type>
 	<unique>true</unique>

--- a/force-app/main/default/triggers/IssueWatcherTrigger.trigger
+++ b/force-app/main/default/triggers/IssueWatcherTrigger.trigger
@@ -1,0 +1,4 @@
+trigger IssueWatcherTrigger on acn__IssueWatcher__c (before insert, before update) {
+    IssueWatcherTriggerHandler.getInstance().run(acn__IssueWatcher__c.SObjectType);
+
+}

--- a/force-app/main/default/triggers/IssueWatcherTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/IssueWatcherTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>54.0</apiVersion>
+  <status>Active</status>
+</ApexTrigger>


### PR DESCRIPTION
 La clave única esta formada por la concatenación del Id de la issue y el id del contacto, con un guión bajo. (IdIssue + _  IdContact)