### PR TITLE
Creado control de asignación de Issues

### DIFF
--- a/force-app/main/default/classes/IssueTriggerHandler.cls
+++ b/force-app/main/default/classes/IssueTriggerHandler.cls
@@ -1,71 +1,78 @@
-public without sharing class IssueTriggerHandler extends TriggerHandler {
+public without sharing class IssueTriggerHandler extends TriggerHandler{
     private static IssueTriggerHandler singleton;
     private Map<Id, acn__Project__c> projectMap = new Map<Id, acn__Project__c>();
     private Map<Id, acn__Project__c> projectsToUpdate = new Map<Id, acn__Project__c>();
-    private IssueTriggerHandler() {
+    private Map<Id, List<acn__ProjectCollaborator__c>> projectCollaboratorByProject = new Map<Id, List<acn__ProjectCollaborator__c>>();
+    private Map<Id, Set<Id>> projectCollaboratorContactIdsByProject = new Map<Id, Set<Id>>();
+    private IssueTriggerHandler(){
     }
 
-    public static IssueTriggerHandler getInstance() {
-        if (singleton == null) {
+    public static IssueTriggerHandler getInstance(){
+        if (singleton == null){
             singleton = new IssueTriggerHandler();
         }
         return singleton;
     }
 
-    public override void bulkInsert(List<SObject> newList) {
+    public override void bulkInsert(List<SObject> newList){
         Set<Id> projectIds = new Set<Id>();
-        for (SObject newRecord : newList) {
+        for (SObject newRecord : newList){
             acn__Issue__c newIssue = (acn__Issue__c) newRecord;
-            if (!projectMap.containsKey(newIssue.acn__Project__c)) {
+            if (!projectMap.containsKey(newIssue.acn__Project__c)){
                 projectIds.add(newIssue.acn__Project__c);
             }
         }
         getProjectData(projectIds);
     }
 
-    public override void bulkUpdate(Map<Id, SObject> newMap, Map<Id, SObject> oldMap) {
+    public override void bulkUpdate(Map<Id, SObject> newMap, Map<Id, SObject> oldMap){
         Set<Id> projectIds = new Set<Id>();
-        for (SObject newRecord : newMap.values()) {
+        for (SObject newRecord : newMap.values()){
             acn__Issue__c newIssue = (acn__Issue__c) newRecord;
             acn__Issue__c oldIssue = (acn__Issue__c) oldMap.get(newIssue.Id);
-            if (!projectMap.containsKey(newIssue.acn__Project__c)) {
+            if (!projectMap.containsKey(newIssue.acn__Project__c)){
                 projectIds.add(newIssue.acn__Project__c);
             }
-            if (!projectMap.containsKey(oldIssue.acn__Project__c)) {
+            if (!projectMap.containsKey(oldIssue.acn__Project__c)){
                 projectIds.add(oldIssue.acn__Project__c);
             }
         }
         getProjectData(projectIds);
     }
 
-    public override void beforeInsert(SObject newRecord) {
+    public override void beforeInsert(SObject newRecord){
         acn__Issue__c newIssue = (acn__Issue__c) newRecord;
         acn__Project__c project = projectMap.get(newIssue.acn__Project__c);
         IssueTriggerHelper.setIssueName(newIssue, project);
     }
 
-    public override void afterInsert(SObject newRecord) {
+    public override void afterInsert(SObject newRecord){
         acn__Issue__c newIssue = (acn__Issue__c) newRecord;
-        acn__Project__c project = projectMap.get(newIssue.acn__Project__c);
+        acn__Project__c project = projectMap.get(newIssue.acn__Project__c);        
+        Set<Id> projectCollaboratorComtactIds = projectCollaboratorContactIdsByProject.get(newIssue.acn__Project__c);
+        IssueTriggerHelper.validateIssueAssigment(newIssue,projectCollaboratorComtactIds);
         IssueTriggerHelper.incrementIssueCount(project);
         projectsToUpdate.put(project.Id, project);
     }
 
-    public override void beforeUpdate(SObject newRecord, SObject oldRecord) {
+    public override void beforeUpdate(SObject newRecord, SObject oldRecord){
         acn__Issue__c newIssue = (acn__Issue__c) newRecord;
         acn__Issue__c oldIssue = (acn__Issue__c) oldRecord;
         acn__Project__c project = projectMap.get(newIssue.acn__Project__c);
-        if (newIssue.acn__Project__c != oldIssue.acn__Project__c) {
+        Set<Id> projectCollaboratorComtactIds = projectCollaboratorContactIdsByProject.get(newIssue.acn__Project__c);
+        if (newIssue.acn__Project__c != oldIssue.acn__Project__c){
             IssueTriggerHelper.setIssueName(newIssue, project);
         }
+        IssueTriggerHelper.validateIssueAssigment(newIssue, projectCollaboratorComtactIds);
+        
     }
 
-    public override void afterUpdate(SObject newRecord, SObject oldRecord) {
+    public override void afterUpdate(SObject newRecord, SObject oldRecord){
         acn__Issue__c newIssue = (acn__Issue__c) newRecord;
         acn__Issue__c oldIssue = (acn__Issue__c) oldRecord;
         acn__Project__c project = projectMap.get(newIssue.acn__Project__c);
         acn__Project__c oldProject = projectMap.get(oldIssue.acn__Project__c);
-        if (newIssue.acn__Project__c != oldIssue.acn__Project__c) {
+        if (newIssue.acn__Project__c != oldIssue.acn__Project__c){
             IssueTriggerHelper.incrementIssueCount(project);
             IssueTriggerHelper.decrementIssueCount(oldProject);
             projectsToUpdate.put(project.Id, project);
@@ -73,19 +80,33 @@ public without sharing class IssueTriggerHandler extends TriggerHandler {
         }
     }
 
-    public override void onFinally() {
-        if (projectsToUpdate.size() > 0) {
+    public override void onFinally(){
+        if (projectsToUpdate.size() > 0){
             update projectsToUpdate.values();
             projectsToUpdate.clear();
         }
     }
 
-    private void getProjectData(Set<Id> projectIds) {
-        if (projectIds.size() > 0) {
+    private void getProjectData(Set<Id> projectIds){
+        if (projectIds.size() > 0){
             Set<Id> tmpIds = CollectionUtils.mergeSet(projectIds, projectMap.keySet());
             projectMap = new Map<Id, acn__Project__c>([Select Id, Name, acn__Code__c, acn__IssuesCount__c
                                                        from acn__Project__c
                                                        where Id in:tmpIds]);
+
+            for (acn__ProjectCollaborator__c projectCollaborator : [Select Id, acn__Project__c, acn__Contact__c
+                                                                    from acn__ProjectCollaborator__c
+                                                                    where acn__Project__c in :projectMap.keySet()]){
+                if (!projectCollaboratorByProject.containsKey(projectCollaborator.acn__Project__c)){
+                    projectCollaboratorByProject.put(projectCollaborator.acn__Project__c, new List<acn__ProjectCollaborator__c>());
+                }
+                projectCollaboratorByProject.get(projectCollaborator.acn__Project__c).add(projectCollaborator);
+
+                if(!projectCollaboratorContactIdsByProject.containsKey(projectCollaborator.acn__Project__c)){
+                    projectCollaboratorContactIdsByProject.put(projectCollaborator.acn__Project__c, new Set<Id>());
+                }
+                projectCollaboratorContactIdsByProject.get(projectCollaborator.acn__Project__c).add(projectCollaborator.acn__Contact__c);
+            }
         }
     }
 

--- a/force-app/main/default/classes/IssueTriggerHelper.cls
+++ b/force-app/main/default/classes/IssueTriggerHelper.cls
@@ -22,4 +22,12 @@ public with sharing class IssueTriggerHelper {
         return (project.acn__IssuesCount__c != null) ? project.acn__IssuesCount__c.intValue() : 0;
     }
 
+    public static void validateIssueAssigment(acn__Issue__c newIssue, Set<Id> projectCollaboratorsContactIds){
+        if(projectCollaboratorsContactIds == null || projectCollaboratorsContactIds.size() == 0 ){
+            newIssue.addError(Label.IssueContactAssignError);
+        } else if (!projectCollaboratorsContactIds.contains(newIssue.acn__AssignedTo__c)){
+            newIssue.addError(Label.IssueContactAssignError);
+        }
+     }
+
 }

--- a/force-app/main/default/classes/IssueTriggerTest.cls
+++ b/force-app/main/default/classes/IssueTriggerTest.cls
@@ -1,5 +1,16 @@
 @isTest
 public with sharing class IssueTriggerTest {
+
+    private static Account account {
+        get {
+            if(account == null){
+                account = [Select Id from account where name = 'Test Account'];
+            }
+            return account;
+        }
+        set;
+    }
+
     
     private static Contact contact {
         get {
@@ -33,7 +44,7 @@ public with sharing class IssueTriggerTest {
 
     @TestSetup
     public static void testSetup(){
-        Account account = TestDataFactory.createAccount('Test Account');
+        account = TestDataFactory.createAccount('Test Account');
         insert account;
         contact = TestDataFactory.createContact('Test Contact', account.Id, UserInfo.getUserId());
         insert contact;
@@ -41,6 +52,10 @@ public with sharing class IssueTriggerTest {
         insert project;
         project2 = TestDataFactory.createProject('Test Project 2', 'TEST2', contact.Id);
         insert project2;
+        acn__ProjectCollaborator__c projectCollaborator = TestDataFactory.createProjectCollaborator(contact.Id, project.Id);
+        insert projectCollaborator;
+        acn__ProjectCollaborator__c projectCollaborator2 = TestDataFactory.createProjectCollaborator(contact.Id, project2.Id);
+        insert projectCollaborator2;
     }
 
     @isTest
@@ -89,6 +104,62 @@ public with sharing class IssueTriggerTest {
         system.assertEquals('TEST2-00001', issueResult.Name);
         system.assertEquals(0, projectResult.acn__IssuesCount__c);
         system.assertEquals(1, project2Result.acn__IssuesCount__c);
+    }
+
+    @isTest
+    public static void testValidateIssueAssignmentOnInsert(){
+
+        Contact contact2 = TestDataFactory.createContact('Test Contact 2', account.Id, UserInfo.getUserId());
+        insert contact2;
+
+        acn__Issue__c newIssue = new acn__Issue__c();
+        newIssue.acn__AssignedTo__c = contact2.Id;
+        newIssue.acn__OpenedBy__c = contact2.Id;
+        newIssue.acn__Headline__c = 'Test Headline';
+        newIssue.acn__EstimatedTime__c = 50;
+        newIssue.acn__StartDate__c = System.today().addDays(1);
+        newIssue.acn__Status__c = 'Opened';
+        newIssue.acn__Project__c = project.Id;
+        newIssue.acn__Description__c = 'Test Issue';
+
+        Test.startTest();
+        try {
+            insert newIssue; 
+            System.assert(false, 'Esta linea no debería ejecutarse');
+        } catch (Exception e) {
+            System.assert(e.getMessage().contains(Label.IssueContactAssignError), e.getMessage());
+        }       
+        Test.stopTest();        
+    }
+
+     @isTest
+    public static void testValidateIssueAssignmentOnUpdate(){
+
+        acn__Issue__c newIssue = new acn__Issue__c();
+        newIssue.acn__AssignedTo__c = contact.Id;
+        newIssue.acn__OpenedBy__c = contact.Id;
+        newIssue.acn__Headline__c = 'Test Headline';
+        newIssue.acn__EstimatedTime__c = 50;
+        newIssue.acn__StartDate__c = System.today().addDays(1);
+        newIssue.acn__Status__c = 'Opened';
+        newIssue.acn__Project__c = project.Id;
+        newIssue.acn__Description__c = 'Test Issue';
+
+        Contact contact2 = TestDataFactory.createContact('Test Contact 2', account.Id, UserInfo.getUserId());
+        insert contact2;
+
+        Test.startTest();
+        try {
+            insert newIssue; 
+            newIssue.acn__Assignedto__c = contact2.Id;
+            update newIssue;
+            System.assert(false, 'Esta linea no debería ejecutarse');
+        } catch (Exception e) {
+            System.assert(e.getMessage().contains(Label.IssueContactAssignError), e.getMessage());
+        }       
+        Test.stopTest();
+
+
     }
 
 

--- a/force-app/main/default/classes/TestDataFactory.cls
+++ b/force-app/main/default/classes/TestDataFactory.cls
@@ -39,6 +39,14 @@ public with sharing class TestDataFactory {
         newIssue.acn__Description__c = 'Test Description';
         return newIssue;
     }
+
+    public static acn__ProjectCollaborator__c createProjectCollaborator(Id contactId, Id projectId){
+        acn__ProjectCollaborator__c newProjectColaborator = new acn__ProjectCollaborator__c();
+        newProjectColaborator.acn__Contact__c = contactId;
+        newProjectColaborator.acn__Project__c = projectId;
+        newProjectColaborator.acn__Role__c = 'Desarrollador';
+        return newProjectColaborator;
+    }
     
 
 }

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
+	<labels><categories>Error</categories><fullName>IssueContactAssignError</fullName><language>en_US</language><protected>false</protected><shortDescription>Label para mostrar un error en caso de asignar una issue a un usuario incorrecto</shortDescription><value>You cannot assign issues to people who do not belong to the project</value></labels>
+</CustomLabels>


### PR DESCRIPTION
Controla que no se pueda asignar una Issue__c a una persona que no sea colaboradora del mismo proyecto al que pertenece la issue.